### PR TITLE
Add markdownlint workflow for README on pull requests

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,23 @@
+name: Markdown Lint
+
+on:
+  pull_request:
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install markdownlint
+        run: npm install --global markdownlint-cli
+
+      - name: Lint README
+        run: markdownlint README.md

--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ Otras funciones incluidas en esta version:
 - Gestor basico de metas financieras.
 - Sistema de notificaciones simple.
 - Esqueleto de gestion de usuarios y consulta a la API de Banxico.
+
+## CI
+
+Se agrego un workflow de GitHub Actions (`.github/workflows/markdownlint.yml`) que ejecuta `markdownlint` sobre `README.md` en cada pull request.


### PR DESCRIPTION
### Motivation
- Add automated markdown linting for `README.md` on pull requests to catch formatting and style issues early.

### Description
- Add `.github/workflows/markdownlint.yml` (triggered on `pull_request`) which checks out the repo, sets up Node (`actions/setup-node@v4` with `node-version: '20'`), installs `markdownlint-cli` and runs `markdownlint README.md`, and append a brief `## CI` note to `README.md` documenting the new workflow.

### Testing
- Attempted to run `npx --yes markdownlint-cli README.md` locally but it failed with an npm registry `403` error due to environment/security policy, so no successful local lint run was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_698fb35682048323b8e10f43edd607e4)